### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ ENTRYPOINT [ "npm", "start" ]
 ##############################################################################
 LABEL name="smee-io"
 LABEL version=$BUILD_VERSION
-LABEL description="Smee.IO: https://smee.io/ \r\nReceives payloads then sends them to your locally running application."
+LABEL description="Smee.io: https://smee.io/ \r\nReceives payloads then sends them to your locally running application."
 LABEL org.label-schema.vendor="Smee.io" 
 LABEL org.label-schema.build-date=$BUILD_DATE 
 LABEL org.label-schema.version=$BUILD_VERSION 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ FROM node:lts-alpine as build-env
 ## > See about optimization: https://www.aptible.com/documentation/enclave/tutorials/faq/dockerfile-caching/npm-dockerfile-caching.html
 WORKDIR /source
 ADD . .
-RUN npm install
+RUN npm ci
 
 ##############################################################################
 # Build the final runtime container

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ FROM node:lts-alpine as build-env
 ## > See about optimization: https://www.aptible.com/documentation/enclave/tutorials/faq/dockerfile-caching/npm-dockerfile-caching.html
 WORKDIR /source
 ADD . .
-RUN npm install --production --unsafe-perm
+RUN npm install
 
 ##############################################################################
 # Build the final runtime container

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "smee-server",
-  "version": "0.0.3",
-  "description": "",
+  "name": "smee.io",
+  "private": true,
+  "description": "Receives payloads then sends them to your locally running application.",
   "author": "Jason Etcovitch <jasonetco@gmail.com> (https://github.com/JasonEtco)",
   "license": "ISC",
   "repository": "https://github.com/probot/smee.git",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "webpack-cli": "^3.3.11"
   },
   "engines": {
-    "node": "10.x.x"
+    "node": "12.x.x"
   },
   "jest": {
     "globalSetup": "./tests/global-setup.js",


### PR DESCRIPTION
Makes a couple tweaks to the `package.json`, and fixes the Dockerfile to install more than just `dependencies` (by removing the `--production` flag) and replacing `npm install` with `npm ci`.

Closes https://github.com/probot/smee.io/issues/40