### PR TITLE
Use relative links instead of absolute

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -49,7 +49,7 @@ module.exports = (testRoute) => {
       .toString('base64')
       .replace(/[+/=]+/g, '')
 
-    res.redirect(307, `${protocol}://${host}/${channel}`)
+    res.redirect(307, `${channel}`)
   })
 
   app.get('/:channel', (req, res, next) => {

--- a/public/index.html
+++ b/public/index.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>smee.io | Webhook payload delivery service</title>
-  <link rel="shortcut icon" href="/public/favicon.png">
-  <link rel="stylesheet" href="/public/main.min.css">
+  <link rel="shortcut icon" href="public/favicon.png">
+  <link rel="stylesheet" href="public/main.min.css">
 </head>
 <body>
   <header class="text-white text-center p-responsive bg-blue d-flex flex-column flex-items-center flex-justify-center" style="height: 80vh">
@@ -19,7 +19,7 @@
     <h1 class="f00-light">smee.io</h1>
     <h2 class="blue-700">Webhook payload delivery service</h2>
     <p class="lead text-white" style="opacity: 0.8">Receives payloads then sends them to your locally running application.</p>
-    <a href="/new" class="btn btn-outline btn-outline-blue">Start a new channel</a>
+    <a href="new" class="btn btn-outline btn-outline-blue">Start a new channel</a>
   </header>
 
   <main class="container-lg py-6 mt-6 p-responsive">

--- a/public/webhooks.html
+++ b/public/webhooks.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>smee.io | Webhook deliveries</title>
-  <link rel="shortcut icon" href="/public/favicon.png">
-  <link rel="stylesheet" href="/public/main.min.css">
+  <link rel="shortcut icon" href="public/favicon.png">
+  <link rel="stylesheet" href="public/main.min.css">
 </head>
 <body>
   <noscript>
@@ -16,7 +16,7 @@
     </div>
   </noscript>
   <div class="mount"></div>
-  <script src="/public/main.min.js"></script>
+  <script src="public/main.min.js"></script>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-102577034-3"></script>
   <script>
     window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
Use relative links instead of absolute to make project useable behind ingress using a context path, i.e. https://server:port/contextPath/

Fixes #48 