### PR TITLE
Add CI job to build Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,9 @@ jobs:
       run: npx codecov
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: docker build .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Node CI
+name: CI
 
 on:
   pull_request:
@@ -7,22 +7,18 @@ on:
       - master
 
 jobs:
-  build:
-
+  tests:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [10.x, 12.x]
-
     services:
       redis:
         image: redis
         ports:
         - 6379:6379
-
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: docker build .
+    - run: docker build . -t smee.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,10 @@ COPY --chown=node:node --from=bundles /usr/src/smee.io/public /usr/src/smee.io/p
 ENV NODE_ENV production
 
 # Copy various scripts and files
+COPY --chown=node:node public ./public
 COPY --chown=node:node lib ./lib
 COPY --chown=node:node index.js ./index.js
+COPY --chown=node:node package*.json ./
 
 EXPOSE 3000
 CMD ["npm", "start"]


### PR DESCRIPTION
This adds a job to our CI workflow to build the Docker image. This is specifically to prevent issues like #51! I'll also fix it in this PR.