### PR TITLE
Remove Google Analytics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -45,13 +45,5 @@
   <footer class="border-top text-center py-4 text-gray">
     Made with <svg height="16" class="octicon octicon-heart" viewBox="0 0 12 16" version="1.1" width="12" aria-hidden="true"><path fill-rule="evenodd" d="M11.2 3c-.52-.63-1.25-.95-2.2-1-.97 0-1.69.42-2.2 1-.51.58-.78.92-.8 1-.02-.08-.28-.42-.8-1-.52-.58-1.17-1-2.2-1-.95.05-1.69.38-2.2 1-.52.61-.78 1.28-.8 2 0 .52.09 1.52.67 2.67C1.25 8.82 3.01 10.61 6 13c2.98-2.39 4.77-4.17 5.34-5.33C11.91 6.51 12 5.5 12 5c-.02-.72-.28-1.39-.8-2.02V3z"></path></svg> by the <a href="https://github.com/probot" target="_blank" rel="noopener noreferrer">Probot team</a>.
   </footer>
-
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-102577034-3"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-102577034-3');
-  </script>
 </body>
 </html>

--- a/public/webhooks.html
+++ b/public/webhooks.html
@@ -17,12 +17,5 @@
   </noscript>
   <div class="mount"></div>
   <script src="/public/main.min.js"></script>
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-102577034-3"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-102577034-3');
-  </script>
 </body>
 </html>

--- a/tests/__snapshots__/server.test.js.snap
+++ b/tests/__snapshots__/server.test.js.snap
@@ -48,14 +48,6 @@ exports[`server GET / returns the proper HTML 1`] = `
   <footer class=\\"border-top text-center py-4 text-gray\\">
     Made with <svg height=\\"16\\" class=\\"octicon octicon-heart\\" viewBox=\\"0 0 12 16\\" version=\\"1.1\\" width=\\"12\\" aria-hidden=\\"true\\"><path fill-rule=\\"evenodd\\" d=\\"M11.2 3c-.52-.63-1.25-.95-2.2-1-.97 0-1.69.42-2.2 1-.51.58-.78.92-.8 1-.02-.08-.28-.42-.8-1-.52-.58-1.17-1-2.2-1-.95.05-1.69.38-2.2 1-.52.61-.78 1.28-.8 2 0 .52.09 1.52.67 2.67C1.25 8.82 3.01 10.61 6 13c2.98-2.39 4.77-4.17 5.34-5.33C11.91 6.51 12 5.5 12 5c-.02-.72-.28-1.39-.8-2.02V3z\\"></path></svg> by the <a href=\\"https://github.com/probot\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">Probot team</a>.
   </footer>
-
-  <script async src=\\"https://www.googletagmanager.com/gtag/js?id=UA-102577034-3\\"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-102577034-3');
-  </script>
 </body>
 </html>
 "
@@ -81,13 +73,6 @@ exports[`server GET /:channel returns the proper HTML 1`] = `
   </noscript>
   <div class=\\"mount\\"></div>
   <script src=\\"/public/main.min.js\\"></script>
-  <script async src=\\"https://www.googletagmanager.com/gtag/js?id=UA-102577034-3\\"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-102577034-3');
-  </script>
 </body>
 </html>
 "


### PR DESCRIPTION
Removes Google Analytics, per https://github.blog/2020-12-17-no-cookie-for-you/. We don't use it much anyway!