### PR TITLE
Fix README.md smee.io channel URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Smee.io is a simple Node.js application. You can deploy it any way you would dep
 Don't forget to point `smee-client` to your instance of `smee.io`:
 
 ```
-smee --url https://your-smee.io/channel 
+smee --url https://smee.io/<your-channel>
 ```
 
 ### Running multiple instances of Smee.io


### PR DESCRIPTION
Make the smee.io channel URL look more relevant and closer to the real world URL

-----
[View rendered README.md](https://github.com/dpkshetty/smee.io/blob/master/README.md)