### PR TITLE
Adding GitHub Workflows to create tag and release Docker image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,45 @@
+name: Docker release
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: smee.io
+
+jobs:
+  image:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - run: echo ${{ github.actor }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,0 +1,36 @@
+name: Create tag
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - closed
+    paths-ignore:
+      - LICENSE
+      - README.md
+      - .github/**
+      - .*
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  tag:
+    name: Tagging
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          fetch-depth: 0
+
+      - name: Create new tag
+        id: version
+        run: |
+            LAST_TAG=$(git tag --sort=creatordate --sort=v:refname | tail -n1)
+            NEW_TAG=$(echo "$LAST_TAG" | awk '{split(substr($0, 2), a, "."); printf "v%d.%d.%d", a[1], a[2], a[3]+1}')
+            git tag $NEW_TAG
+            git push --tags

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -24,7 +24,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           fetch-depth: 0
 
       - name: Create new tag


### PR DESCRIPTION
This PR is adding two GitHub Workflows that automatically create Git tag and publish Docker image on every merged PR. The Docker image is pushed into the GitHub Container Registry (GHCR) and will be visible in the repo as a [Package](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages).