### PR TITLE
Simplify code for splitting blocked channels list.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -181,7 +181,7 @@ const [
       this.raw.write(`id: ${this.message_count++}\n${event ? `event: ${event}\n` : ''}data: ${JSON.stringify(payload)}\n\n`)
     })
 
-  const channelsBlocked = new Set(process.env.BLOCKED_CHANNELS ? process.env.BLOCKED_CHANNELS.split(',') : [])
+  const channelsBlocked = new Set((process.env.BLOCKED_CHANNELS || '').split(','))
 
   const channelsBlockedHandler = channelsBlocked.size !== 0
     ? (req, reply, done) => {


### PR DESCRIPTION
There should be a single point of truth for the variable name. And in this case, it even saves some bytes. (Omission of the semicola makes me think you optimize for that.)
If we care about not having an empty string item in the set, we should explicitly delete the empty string item, so people get the tiny perfomance benefit even if they set the env var to `,` or `,,,,` for external (scripting/ orchestration tools) reasons.